### PR TITLE
Disable optimization in su_use_stack (#12)

### DIFF
--- a/src/sumain.c
+++ b/src/sumain.c
@@ -57,6 +57,12 @@ __attribute__ ((section ("__DATA,__interpose"))) = { (const void *)(unsigned lon
                                                      (const void *)(unsigned long)&_orgfun }
 #endif
 
+#if defined(__clang__)
+#define OPTIMIZE_NONE __attribute__ ((optnone))
+#else
+#define OPTIMIZE_NONE __attribute__ ((optimize("O0")))
+#endif
+
 
 /* ----------- Types --------------------------------------------- */
 typedef struct
@@ -101,7 +107,7 @@ void signal_handler(int);
 
 /* ----------- Local Function Prototypes ------------------------- */
 static void *su_start_thread(void *arg);
-static void su_use_stack(char *base, long size);
+static void OPTIMIZE_NONE su_use_stack(char *base, long size);
 static void su_thread_init(su_threadtype_t threadtype, pthread_attr_t *rattr,
                            void *func_ptr);
 static void su_thread_fini(void *key);
@@ -281,7 +287,7 @@ static void *su_start_thread(void *startarg)
 }
 
 
-static void su_use_stack(char *base, long size)
+static void OPTIMIZE_NONE su_use_stack(char *base, long size)
 {
   char arr[SU_DUMMY_USE];
   char here;
@@ -289,10 +295,6 @@ static void su_use_stack(char *base, long size)
   if ((labs(&here - base) + SU_DUMMY_USE) < size)
   {
     su_use_stack(base, size);
-  }
-  else
-  {
-    return;
   }
 }
 


### PR DESCRIPTION
With optimization enabled, the compiler may elide the stack based array
allocated by su_use_stack, thus causing this function to run for a very
long time.

Tested on Ubuntu 16.04.6 (i386, kernel 4.15.0-45-generic, gcc 5.4.0).
Tested on custom Yocto (i.MX53, kernel 5.15.22, gcc 9.3.0).
Tested on macOS Catalina (Apple clang version clang-1200.0.32.29).